### PR TITLE
feat: add opt-in --live-check, --typing and --wait-ack flags to send commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,14 @@ as a playable message in the chat:
 npx mudslide@latest send-file --type audio 123456789-987654321@g.us music.mp3
 ```
 
+## General send options
+
+For message and file sending commands the following options are available:
+
+- **--live-check**: Verify the recipient exists on WhatsApp before sending
+- **--typing <ms>**: Simulate typing indicator for the given duration (ms) before sending
+- **-wait-ack <ms>**: Wait for delivery acknowledgement after sending, up to the given timeout (ms)
+
 ## Sending a location
 
 Geographic locations can be sent to individuals or groups using latitude and

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,17 +7,17 @@ import {
     handleNewlines,
     initWASocket,
     parseGeoLocation,
-    SendChecksOptions,
     sendFileHelper,
     sendImageHelper,
-    sendPayload,
+    sendSocketMessage,
     terminate
 } from "./whatsapp";
+import {GeneralSendOptions} from "./entities/GeneralSendOptions";
 
 export async function sendMessage(recipient: string, message: string, options: {
     footer: string | undefined,
     button: Array<string>
-} & SendChecksOptions) {
+} & GeneralSendOptions) {
     checkLoggedIn();
     const socket = await initWASocket();
     socket.ev.on('connection.update', async (update) => {
@@ -39,12 +39,12 @@ export async function sendMessage(recipient: string, message: string, options: {
                 whatsappMessage['buttons'] = buttons;
                 whatsappMessage['headerType'] = 1;
             }
-            await sendPayload(socket, whatsappId, whatsappMessage, options);
+            await sendSocketMessage(socket, whatsappId, whatsappMessage, options);
         }
     });
 }
 
-export async function sendImage(recipient: string, path: string, options: { caption: string | undefined } & SendChecksOptions) {
+export async function sendImage(recipient: string, path: string, options: { caption: string | undefined } & GeneralSendOptions) {
     checkValidFile(path);
     checkLoggedIn();
     const socket = await initWASocket();
@@ -61,7 +61,7 @@ export async function sendImage(recipient: string, path: string, options: { capt
 export async function sendFile(recipient: string, path: string, options: {
     caption: string | undefined,
     type: 'audio' | 'video' | 'document'
-} & SendChecksOptions) {
+} & GeneralSendOptions) {
     checkValidFile(path);
     checkLoggedIn();
     const socket = await initWASocket();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,15 +7,17 @@ import {
     handleNewlines,
     initWASocket,
     parseGeoLocation,
+    SendChecksOptions,
     sendFileHelper,
     sendImageHelper,
+    sendPayload,
     terminate
 } from "./whatsapp";
 
 export async function sendMessage(recipient: string, message: string, options: {
     footer: string | undefined,
     button: Array<string>
-}) {
+} & SendChecksOptions) {
     checkLoggedIn();
     const socket = await initWASocket();
     socket.ev.on('connection.update', async (update) => {
@@ -37,14 +39,12 @@ export async function sendMessage(recipient: string, message: string, options: {
                 whatsappMessage['buttons'] = buttons;
                 whatsappMessage['headerType'] = 1;
             }
-            await socket.sendMessage(whatsappId, whatsappMessage);
-            signale.success('Done');
-            await terminate(socket, 3);
+            await sendPayload(socket, whatsappId, whatsappMessage, options);
         }
     });
 }
 
-export async function sendImage(recipient: string, path: string, options: { caption: string | undefined }) {
+export async function sendImage(recipient: string, path: string, options: { caption: string | undefined } & SendChecksOptions) {
     checkValidFile(path);
     checkLoggedIn();
     const socket = await initWASocket();
@@ -61,7 +61,7 @@ export async function sendImage(recipient: string, path: string, options: { capt
 export async function sendFile(recipient: string, path: string, options: {
     caption: string | undefined,
     type: 'audio' | 'video' | 'document'
-}) {
+} & SendChecksOptions) {
     checkValidFile(path);
     checkLoggedIn();
     const socket = await initWASocket();

--- a/src/entities/GeneralSendOptions.ts
+++ b/src/entities/GeneralSendOptions.ts
@@ -1,5 +1,4 @@
 export type GeneralSendOptions = {
-    liveCheck?: boolean,
-    typing?: number,
-    waitAck?: number
+    liveCheck?: boolean;
+    typing?: number;
 }

--- a/src/entities/GeneralSendOptions.ts
+++ b/src/entities/GeneralSendOptions.ts
@@ -1,0 +1,5 @@
+export type GeneralSendOptions = {
+    liveCheck?: boolean,
+    typing?: number,
+    waitAck?: number
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,7 @@ function configureBasicCommands() {
 function addGeneralSendOptions(command: Command) {
     return command
         .option('--live-check', 'Verify the recipient exists on WhatsApp before sending')
-        .option('--typing <ms>', 'Simulate typing indicator for the given duration (ms) before sending', parseInt)
-        .option('--wait-ack <ms>', 'Wait for delivery acknowledgement after sending, up to the given timeout (ms)', parseInt);
+        .option('--typing <ms>', 'Simulate typing indicator for the given duration (ms) before sending', parseInt);
 }
 
 function configureSendCommands() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ function configureBasicCommands() {
         .action(() => me());
 }
 
-function addSendChecksOptions(command: Command) {
+function addGeneralSendOptions(command: Command) {
     return command
         .option('--live-check', 'Verify the recipient exists on WhatsApp before sending')
         .option('--typing <ms>', 'Simulate typing indicator for the given duration (ms) before sending', parseInt)
@@ -79,18 +79,18 @@ function addSendChecksOptions(command: Command) {
 }
 
 function configureSendCommands() {
-    addSendChecksOptions(program
+    addGeneralSendOptions(program
         .command('send <recipient> <message>')
         .description('Send message'))
         .action((recipient, message, options) => sendMessage(recipient, message, options));
 
-    addSendChecksOptions(program
+    addGeneralSendOptions(program
         .command('send-image <recipient> <file>')
         .option('--caption <text>', 'Caption text')
         .description('Send image file'))
         .action((recipient, file, options) => sendImage(recipient, file, options));
 
-    addSendChecksOptions(program
+    addGeneralSendOptions(program
         .command('send-file <recipient> <file>')
         .option('--caption <text>', 'Caption text')
         .option('--type <document|audio|video>', 'File type', 'document')

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,23 +71,30 @@ function configureBasicCommands() {
         .action(() => me());
 }
 
+function addSendChecksOptions(command: Command) {
+    return command
+        .option('--live-check', 'Verify the recipient exists on WhatsApp before sending')
+        .option('--typing <ms>', 'Simulate typing indicator for the given duration (ms) before sending', parseInt)
+        .option('--wait-ack <ms>', 'Wait for delivery acknowledgement after sending, up to the given timeout (ms)', parseInt);
+}
+
 function configureSendCommands() {
-    program
+    addSendChecksOptions(program
         .command('send <recipient> <message>')
-        .description('Send message')
+        .description('Send message'))
         .action((recipient, message, options) => sendMessage(recipient, message, options));
 
-    program
+    addSendChecksOptions(program
         .command('send-image <recipient> <file>')
         .option('--caption <text>', 'Caption text')
-        .description('Send image file')
+        .description('Send image file'))
         .action((recipient, file, options) => sendImage(recipient, file, options));
 
-    program
+    addSendChecksOptions(program
         .command('send-file <recipient> <file>')
         .option('--caption <text>', 'Caption text')
         .option('--type <document|audio|video>', 'File type', 'document')
-        .description('Send file')
+        .description('Send file'))
         .action((recipient, file, options) => sendFile(recipient, file, options));
 
     program

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -8,6 +8,7 @@ import * as os from "os";
 import mime from 'mime';
 import {readPhoneNumber} from "./utils";
 import * as QRCode from 'qrcode-terminal';
+import {GeneralSendOptions} from "./entities/GeneralSendOptions";
 
 export const globalOptions = {
     logLevel: 'silent'
@@ -210,12 +211,6 @@ export async function getWhatsAppId(socket: any, recipient: string) {
     return `${recipient}@s.whatsapp.net`;
 }
 
-export type SendChecksOptions = {
-    liveCheck?: boolean,
-    typing?: number,
-    waitAck?: number
-}
-
 export async function checkNumberExistsOnWhatsApp(socket: any, whatsappId: string): Promise<boolean> {
     const result = await socket.onWhatsApp(whatsappId);
     return !!result?.[0]?.exists;
@@ -250,7 +245,7 @@ export async function waitForDeliveryAck(socket: any, key: any, timeoutMs: numbe
     });
 }
 
-export async function sendPayload(socket: any, whatsappId: string, payload: any, options: SendChecksOptions = {}) {
+export async function sendSocketMessage(socket: any, whatsappId: string, payload: any, options: GeneralSendOptions = {}) {
     if (options.liveCheck) {
         const exists = await checkNumberExistsOnWhatsApp(socket, whatsappId);
         if (!exists) {
@@ -277,13 +272,13 @@ export async function sendPayload(socket: any, whatsappId: string, payload: any,
 
 export async function sendImageHelper(socket: any, whatsappId: string, filePath: string, options: {
     caption: string | undefined
-} & SendChecksOptions) {
+} & GeneralSendOptions) {
     const payload = {image: fs.readFileSync(filePath), caption: handleNewlines(options.caption)}
-    await sendPayload(socket, whatsappId, payload, options);
+    await sendSocketMessage(socket, whatsappId, payload, options);
 }
 
 export async function sendFileHelper(socket: any, whatsappId: string, filePath: string,
-                                     options: { caption: string | undefined, type: 'audio' | 'video' | 'document' } & SendChecksOptions) {
+                                     options: { caption: string | undefined, type: 'audio' | 'video' | 'document' } & GeneralSendOptions) {
     const payload: any = {
         mimetype: mime.getType(filePath),
         caption: handleNewlines(options.caption)
@@ -299,7 +294,7 @@ export async function sendFileHelper(socket: any, whatsappId: string, filePath: 
             payload['document'] = fs.readFileSync(filePath);
             payload['fileName'] = path.basename(filePath)
     }
-    await sendPayload(socket, whatsappId, payload, options);
+    await sendSocketMessage(socket, whatsappId, payload, options);
 }
 
 export function handleNewlines(s?: string): string | undefined {

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -1,4 +1,4 @@
-import makeWASocket, {delay, DisconnectReason, fetchLatestWaWebVersion, useMultiFileAuthState, WAMessageStatus, WASocket} from "baileys";
+import makeWASocket, {delay, DisconnectReason, fetchLatestWaWebVersion, useMultiFileAuthState, WASocket} from "baileys";
 import pino from "pino";
 import path from "path";
 import * as fs from "fs";
@@ -228,30 +228,8 @@ export async function simulateTyping(socket: any, whatsappId: string, ms: number
     await socket.sendPresenceUpdate('paused', whatsappId);
 }
 
-export async function waitForDeliveryAck(socket: any, key: any, timeoutMs: number): Promise<boolean> {
-    return new Promise(resolve => {
-        const cleanup = () => {
-            clearTimeout(timer);
-            socket.ev.off('messages.update', onUpdate);
-        };
-        const onUpdate = (updates: any[]) => {
-            for (const {key: updateKey, update} of updates) {
-                if (updateKey.id === key.id && update.status >= WAMessageStatus.DELIVERY_ACK) {
-                    cleanup();
-                    resolve(true);
-                    return;
-                }
-            }
-        };
-        const timer = setTimeout(() => {
-            cleanup();
-            resolve(false);
-        }, timeoutMs);
-        socket.ev.on('messages.update', onUpdate);
-    });
-}
-
-export async function sendSocketMessage(socket: any, whatsappId: string, payload: any, options: GeneralSendOptions = {}) {
+export async function sendSocketMessage(socket: any, whatsappId: string, payload: any,
+                                        options: GeneralSendOptions = {}) {
     if (options.liveCheck) {
         const exists = await checkNumberExistsOnWhatsApp(socket, whatsappId);
         if (!exists) {
@@ -263,16 +241,8 @@ export async function sendSocketMessage(socket: any, whatsappId: string, payload
     if (options.typing) {
         await simulateTyping(socket, whatsappId, options.typing);
     }
-    const result = await socket.sendMessage(whatsappId, payload);
+    await socket.sendMessage(whatsappId, payload);
     signale.success('Done');
-    if (options.waitAck) {
-        const delivered = await waitForDeliveryAck(socket, result.key, options.waitAck);
-        if (delivered) {
-            signale.success('Delivered');
-        } else {
-            signale.error(`No delivery acknowledgement within ${options.waitAck}ms`);
-        }
-    }
     await terminate(socket, 3);
 }
 
@@ -284,7 +254,10 @@ export async function sendImageHelper(socket: any, whatsappId: string, filePath:
 }
 
 export async function sendFileHelper(socket: any, whatsappId: string, filePath: string,
-                                     options: { caption: string | undefined, type: 'audio' | 'video' | 'document' } & GeneralSendOptions) {
+                                     options: {
+                                         caption: string | undefined,
+                                         type: 'audio' | 'video' | 'document'
+                                     } & GeneralSendOptions) {
     const payload: any = {
         mimetype: mime.getType(filePath),
         caption: handleNewlines(options.caption)

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -1,4 +1,4 @@
-import makeWASocket, {delay, DisconnectReason, fetchLatestWaWebVersion, useMultiFileAuthState, WASocket} from "baileys";
+import makeWASocket, {delay, DisconnectReason, fetchLatestWaWebVersion, useMultiFileAuthState, WAMessageStatus, WASocket} from "baileys";
 import pino from "pino";
 import path from "path";
 import * as fs from "fs";
@@ -210,17 +210,80 @@ export async function getWhatsAppId(socket: any, recipient: string) {
     return `${recipient}@s.whatsapp.net`;
 }
 
-export async function sendImageHelper(socket: any, whatsappId: string, filePath: string, options: {
-    caption: string | undefined
-}) {
-    const payload = {image: fs.readFileSync(filePath), caption: handleNewlines(options.caption)}
-    await socket.sendMessage(whatsappId, payload);
+export type SendChecksOptions = {
+    liveCheck?: boolean,
+    typing?: number,
+    waitAck?: number
+}
+
+export async function checkNumberExistsOnWhatsApp(socket: any, whatsappId: string): Promise<boolean> {
+    const result = await socket.onWhatsApp(whatsappId);
+    return !!result?.[0]?.exists;
+}
+
+export async function simulateTyping(socket: any, whatsappId: string, ms: number) {
+    await socket.sendPresenceUpdate('composing', whatsappId);
+    await delay(ms);
+    await socket.sendPresenceUpdate('paused', whatsappId);
+}
+
+export async function waitForDeliveryAck(socket: any, key: any, timeoutMs: number): Promise<boolean> {
+    return new Promise(resolve => {
+        const cleanup = () => {
+            clearTimeout(timer);
+            socket.ev.off('messages.update', onUpdate);
+        };
+        const onUpdate = (updates: any[]) => {
+            for (const {key: updateKey, update} of updates) {
+                if (updateKey.id === key.id && update.status >= WAMessageStatus.DELIVERY_ACK) {
+                    cleanup();
+                    resolve(true);
+                    return;
+                }
+            }
+        };
+        const timer = setTimeout(() => {
+            cleanup();
+            resolve(false);
+        }, timeoutMs);
+        socket.ev.on('messages.update', onUpdate);
+    });
+}
+
+export async function sendPayload(socket: any, whatsappId: string, payload: any, options: SendChecksOptions = {}) {
+    if (options.liveCheck) {
+        const exists = await checkNumberExistsOnWhatsApp(socket, whatsappId);
+        if (!exists) {
+            signale.error(`Recipient does not exist on WhatsApp: ${whatsappId}`);
+            socket.end(undefined);
+            process.exit(1);
+        }
+    }
+    if (options.typing) {
+        await simulateTyping(socket, whatsappId, options.typing);
+    }
+    const result = await socket.sendMessage(whatsappId, payload);
     signale.success('Done');
+    if (options.waitAck) {
+        const delivered = await waitForDeliveryAck(socket, result.key, options.waitAck);
+        if (delivered) {
+            signale.success('Delivered');
+        } else {
+            signale.error(`No delivery acknowledgement within ${options.waitAck}ms`);
+        }
+    }
     await terminate(socket, 3);
 }
 
+export async function sendImageHelper(socket: any, whatsappId: string, filePath: string, options: {
+    caption: string | undefined
+} & SendChecksOptions) {
+    const payload = {image: fs.readFileSync(filePath), caption: handleNewlines(options.caption)}
+    await sendPayload(socket, whatsappId, payload, options);
+}
+
 export async function sendFileHelper(socket: any, whatsappId: string, filePath: string,
-                                     options: { caption: string | undefined, type: 'audio' | 'video' | 'document' }) {
+                                     options: { caption: string | undefined, type: 'audio' | 'video' | 'document' } & SendChecksOptions) {
     const payload: any = {
         mimetype: mime.getType(filePath),
         caption: handleNewlines(options.caption)
@@ -236,9 +299,7 @@ export async function sendFileHelper(socket: any, whatsappId: string, filePath: 
             payload['document'] = fs.readFileSync(filePath);
             payload['fileName'] = path.basename(filePath)
     }
-    await socket.sendMessage(whatsappId, payload);
-    signale.success('Done');
-    await terminate(socket, 3);
+    await sendPayload(socket, whatsappId, payload, options);
 }
 
 export function handleNewlines(s?: string): string | undefined {

--- a/tests/whatsapp.test.ts
+++ b/tests/whatsapp.test.ts
@@ -1,6 +1,11 @@
 import {expect, test} from 'vitest';
-import {WAMessageStatus} from "baileys";
-import {checkNumberExistsOnWhatsApp, getWhatsAppId, handleNewlines, isLoggedOutDisconnect, parseGeoLocation, waitForDeliveryAck} from "../src/whatsapp";
+import {
+    checkNumberExistsOnWhatsApp,
+    getWhatsAppId,
+    handleNewlines,
+    isLoggedOutDisconnect,
+    parseGeoLocation
+} from "../src/whatsapp";
 
 test('get whatsapp id', async () => {
     expect(await getWhatsAppId({}, '3161234567890')).toBe('3161234567890@s.whatsapp.net');
@@ -49,16 +54,6 @@ test('check number exists on whatsapp', async () => {
     const socket = {onWhatsApp: async () => [{jid: '3161234567890@s.whatsapp.net', exists: true}]};
 
     expect(await checkNumberExistsOnWhatsApp(socket, '3161234567890@s.whatsapp.net')).toBe(true);
-})
-
-test('wait for delivery ack, resolves once the status update arrives', async () => {
-    let onUpdate: (updates: any[]) => void;
-    const socket = {ev: {on: (_: string, cb: any) => onUpdate = cb, off: () => {}}};
-
-    const result = waitForDeliveryAck(socket, {id: 'abc'}, 1000);
-    onUpdate!([{key: {id: 'abc'}, update: {status: WAMessageStatus.DELIVERY_ACK}}]);
-
-    expect(await result).toBe(true);
 })
 
 test('detect logged-out disconnect', () => {

--- a/tests/whatsapp.test.ts
+++ b/tests/whatsapp.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'vitest';
-import {getWhatsAppId, handleNewlines, parseGeoLocation} from "../src/whatsapp";
+import {WAMessageStatus} from "baileys";
+import {checkNumberExistsOnWhatsApp, getWhatsAppId, handleNewlines, parseGeoLocation, waitForDeliveryAck} from "../src/whatsapp";
 
 test('get whatsapp id', async () => {
     expect(await getWhatsAppId({}, '3161234567890')).toBe('3161234567890@s.whatsapp.net');
@@ -42,4 +43,20 @@ test('handle newlines', () => {
     expect(handleNewlines('hello\\nworld')).toBe('hello\nworld');
     expect(handleNewlines('hello\\nworld\\n')).toBe('hello\nworld\n');
     expect(handleNewlines()).toBeUndefined();
+})
+
+test('check number exists on whatsapp', async () => {
+    const socket = {onWhatsApp: async () => [{jid: '3161234567890@s.whatsapp.net', exists: true}]};
+
+    expect(await checkNumberExistsOnWhatsApp(socket, '3161234567890@s.whatsapp.net')).toBe(true);
+})
+
+test('wait for delivery ack, resolves once the status update arrives', async () => {
+    let onUpdate: (updates: any[]) => void;
+    const socket = {ev: {on: (_: string, cb: any) => onUpdate = cb, off: () => {}}};
+
+    const result = waitForDeliveryAck(socket, {id: 'abc'}, 1000);
+    onUpdate!([{key: {id: 'abc'}, update: {status: WAMessageStatus.DELIVERY_ACK}}]);
+
+    expect(await result).toBe(true);
 })


### PR DESCRIPTION
Adds three optional flags to send/send-image/send-file:
- --live-check: verifies the recipient exists on WhatsApp (via Baileys' onWhatsApp) before sending, instead of firing blind
- --typing <ms>: shows a "composing..." presence indicator for the given duration before sending
- --wait-ack <ms>: waits for a delivery/read receipt (messages.update status) after sending, up to the given timeout

All three are opt-in and default to off, so existing behavior is unchanged unless a flag is passed. Logic is centralized in a new sendPayload() helper shared by all three send commands.

The functionality is currently live (tested) at https://watobot.xyz 