### PR TITLE
feat: fail fast when the device is unlinked from WhatsApp

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,6 +6,7 @@ import {
     getWhatsAppId,
     handleNewlines,
     initWASocket,
+    isLoggedOutDisconnect,
     parseGeoLocation,
     sendFileHelper,
     sendImageHelper,
@@ -135,11 +136,15 @@ export async function me() {
     signale.log(`Cache folder: ${getAuthStateCacheFolderLocation()}`);
     const socket = await initWASocket();
     socket.ev.on('connection.update', async (update) => {
-        const {connection} = update
+        const {connection, lastDisconnect} = update
         if (connection === 'open') {
             const user = await socket.user
             signale.log(`Current user: ${user?.id}`);
             await terminate(socket);
+        } else if (connection === 'close') {
+            signale.error(isLoggedOutDisconnect(lastDisconnect) ? 'Device unlinked from WhatsApp' : 'Connection closed unexpectedly');
+            socket.end(undefined);
+            process.exit(1);
         }
     });
 }

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -91,6 +91,10 @@ export function checkValidFile(path: string) {
     }
 }
 
+export function isLoggedOutDisconnect(lastDisconnect: any): boolean {
+    return (lastDisconnect?.error as Boom)?.output?.statusCode === DisconnectReason.loggedOut;
+}
+
 export function parseGeoLocation(latitude: string, longitude: string): Array<number> {
     const latitudeFloat = parseFloat(latitude);
     const longitudeFloat = parseFloat(longitude);

--- a/tests/whatsapp.test.ts
+++ b/tests/whatsapp.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'vitest';
-import {getWhatsAppId, handleNewlines, parseGeoLocation} from "../src/whatsapp";
+import {getWhatsAppId, handleNewlines, isLoggedOutDisconnect, parseGeoLocation} from "../src/whatsapp";
 
 test('get whatsapp id', async () => {
     expect(await getWhatsAppId({}, '3161234567890')).toBe('3161234567890@s.whatsapp.net');
@@ -42,4 +42,9 @@ test('handle newlines', () => {
     expect(handleNewlines('hello\\nworld')).toBe('hello\nworld');
     expect(handleNewlines('hello\\nworld\\n')).toBe('hello\nworld\n');
     expect(handleNewlines()).toBeUndefined();
+})
+
+test('detect logged-out disconnect', () => {
+    expect(isLoggedOutDisconnect({error: {output: {statusCode: 401}}})).toBe(true);
+    expect(isLoggedOutDisconnect({error: {output: {statusCode: 500}}})).toBe(false);
 })


### PR DESCRIPTION
`me` only listened for connection.update's 'open' event, so if the device was removed from WhatsApp's own "Linked Devices" list, the locally-cached creds.json still looks valid (checkLoggedIn only checks the file exists) but the actual connection attempt gets an immediate close with statusCode 401 (DisconnectReason.loggedOut) that nothing handled — `me` just hung until the generic --timeout watchdog fired, indistinguishable from a slow network or any other failure.

`me` now handles 'close' explicitly: reports "Device unlinked from WhatsApp" for a loggedOut disconnect (fast, seconds not 60s), or "Connection closed unexpectedly" for any other close reason, instead of hanging. The actual classification (isLoggedOutDisconnect) is a small pure function in whatsapp.ts so it's unit-testable without spinning up a real socket.