### PR TITLE
fix: replace raw unhandled-rejection crashes with a clean exit; fix me's close-handling race

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -135,9 +135,10 @@ export async function me() {
     checkLoggedIn();
     signale.log(`Cache folder: ${getAuthStateCacheFolderLocation()}`);
     const socket = await initWASocket();
-    socket.ev.on('connection.update', async (update) => {
+    const onConnectionUpdate = async (update: any) => {
         const {connection, lastDisconnect} = update
         if (connection === 'open') {
+            socket.ev.off('connection.update', onConnectionUpdate);
             const user = await socket.user
             signale.log(`Current user: ${user?.id}`);
             await terminate(socket);
@@ -146,7 +147,8 @@ export async function me() {
             socket.end(undefined);
             process.exit(1);
         }
-    });
+    };
+    socket.ev.on('connection.update', onConnectionUpdate);
 }
 
 export async function listGroups() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,11 @@ import signale from "signale";
 
 const packageJson = require('../package.json');
 
+process.on('unhandledRejection', (err: any) => {
+    signale.error(err?.message || err);
+    process.exit(1);
+});
+
 program.name('mudslide').version(packageJson.version);
 program.option('-c, --cache <folder>', 'Override cache folder');
 


### PR DESCRIPTION
## Fix 1: catch unhandled rejections

Every command's action handler is an async `connection.update` listener (`socket.ev.on('connection.update', async (update) => {...})`). Node's `EventEmitter` doesn't await or catch rejections thrown by async listeners, so any failed `await` inside one (e.g. a Baileys-internal query timing out) crashed the process with a raw, unhandled stack trace instead of a controlled exit.

Adds a top-level `process.on('unhandledRejection', ...)` that exits cleanly via `signale.error(err?.message || err)` + `process.exit(1)`, matching every other controlled exit path already in the codebase (`checkLoggedIn`, `checkValidFile`, etc). Straightforward.

## Fix 2: `me()` — unregister the `connection.update` listener before `terminate()`

This one needs more explanation. Since #411, `me()`'s listener treats any `connection === 'close'` as an error unless it's a `loggedOut` disconnect (`isLoggedOutDisconnect`). The problem: once `me()` sees a successful `'open'` event, it calls `terminate(socket)`, which does `socket.end(undefined)`.

`socket.end()` is Baileys' internal `end()` closure from `makeSocket` (`src/Socket/socket.ts`), and it unconditionally does:

```js
ev.emit('connection.update', {
    connection: 'close',
    lastDisconnect: { error, date: new Date() }
});
ev.removeAllListeners('connection.update');
```

— note the emit happens *before* Baileys removes its own listeners, so this event still reaches whatever's currently subscribed. Since `me()`'s own handler is still attached at that point, it receives this self-inflicted close, sees it isn't a `loggedOut` disconnect, and calls `process.exit(1)` — racing (and in practice reliably beating) `terminate()`'s own `process.exit()` a couple lines later, after `await socket.ws.close()` yields the event loop. Net effect: `me()` prints the correct `Current user: ...` line, then exits non-zero anyway, every single time.

Fix: unregister the listener (`socket.ev.off('connection.update', onConnectionUpdate)`) the moment `connection === 'open'` fires and we're about to hand off to `terminate()`, so the deliberate close it triggers is no longer caught by this handler.

## Testing

- `npm run build` — clean
- `npx vitest run` — 8/8 passing
- Verified against a real WhatsApp session: before the fix, `me` printed the correct user info but exited 1; after, it exits 0.