### PR TITLE
feat: make Baileys connect/query timeouts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,27 @@ export HTTPS_PROXY=http://USER:PASS@proxy.server.com:80
 npx mudslide@latest --proxy login
 ```
 
-## Timeout
+## Timeouts
+
+### Connection timeout
+
+The default connection timeout is 3000 ms. This duration can be
+changed using the `--connection-timeout <ms>` flag:
+
+```shell
+npx mudslide@latest --connection-timeout 10000 send me 'hello world'
+```
+
+### Query timeout
+
+The default query timeout is 6000 ms. This duration can be changed using the
+`--query-timeout <ms>` flag:
+
+```shell
+npx mudslide@latest --query-timeout 30000 send me 'hello world'
+```
+
+### Command timeout
 
 The default timeout for commands is 60 seconds. This duration can be changed
 using the `--timeout <seconds>` flag:

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,9 +43,10 @@ program.on('option:proxy', () => {
     // @ts-ignore
     global.GLOBAL_AGENT.HTTPS_PROXY = process.env.HTTPS_PROXY;
 });
-program.addOption(new Option('--connect-timeout <ms>', 'Connection timeout').argParser(v => parseInt(v, 10)));
+program.addOption(
+    new Option('--connect-timeout <ms>', 'Connection timeout').default(3_000).argParser(v => parseInt(v, 10)));
 program.on('option:connect-timeout', (ms) => globalOptions.connectTimeoutMs = parseInt(ms, 10));
-program.addOption(new Option('--query-timeout <ms>', 'Query timeout').argParser(v => parseInt(v, 10)));
+program.addOption(new Option('--query-timeout <ms>', 'Query timeout').default(6_000).argParser(v => parseInt(v, 10)));
 program.on('option:query-timeout', (ms) => globalOptions.defaultQueryTimeoutMs = parseInt(ms, 10));
 program.addOption(new Option('--timeout <sec>', 'Command timeout').default(60).argParser(parseInt));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,10 @@ program.on('option:proxy', () => {
     // @ts-ignore
     global.GLOBAL_AGENT.HTTPS_PROXY = process.env.HTTPS_PROXY;
 });
+program.addOption(new Option('--connect-timeout <ms>', 'Connection timeout').argParser(v => parseInt(v, 10)));
+program.on('option:connect-timeout', (ms) => globalOptions.connectTimeoutMs = parseInt(ms, 10));
+program.addOption(new Option('--query-timeout <ms>', 'Query timeout').argParser(v => parseInt(v, 10)));
+program.on('option:query-timeout', (ms) => globalOptions.defaultQueryTimeoutMs = parseInt(ms, 10));
 program.addOption(new Option('--timeout <sec>', 'Command timeout').default(60).argParser(parseInt));
 
 program.hook('preAction', (command: Command) => {

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -10,7 +10,9 @@ import {readPhoneNumber} from "./utils";
 import * as QRCode from 'qrcode-terminal';
 
 export const globalOptions = {
-    logLevel: 'silent'
+    logLevel: 'silent',
+    connectTimeoutMs: 3_000,
+    defaultQueryTimeoutMs: 6_000
 }
 
 export const mudslideFooter = '\u2B50 Please star Mudslide on GitHub! https://github.com/robvanderleek/mudslide';
@@ -47,8 +49,8 @@ export async function initWASocket(message?: string): Promise<WASocket> {
     const os = process.platform === 'darwin' ? 'macOS' : process.platform === 'win32' ? 'Windows' : 'Linux';
     const {version} = await fetchLatestWaWebVersion({});
     const socket = makeWASocket({
-        connectTimeoutMs: 3_000,
-        defaultQueryTimeoutMs: 6_000,
+        connectTimeoutMs: globalOptions.connectTimeoutMs,
+        defaultQueryTimeoutMs: globalOptions.defaultQueryTimeoutMs,
         logger: pino({level: globalOptions.logLevel}),
         auth: state,
         browser: [os, 'Chrome', '10.15.0'],


### PR DESCRIPTION
I use mudslide to route via Residential IP & the connect & query timeout values need to be a bit higher to account for extra proxy delay. The default values in Baileys for these are much higher (20s for connect & 60s for query timeout) while mudslide has put much strict values. Wanting to configure them using this PR while maintaining the default values. 