### PR TITLE
docs: correct --connection-timeout to --connect-timeout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,10 +394,10 @@ npx mudslide@latest --proxy login
 ### Connection timeout
 
 The default connection timeout is 3000 ms. This duration can be
-changed using the `--connection-timeout <ms>` flag:
+changed using the `--connect-timeout <ms>` flag:
 
 ```shell
-npx mudslide@latest --connection-timeout 10000 send me 'hello world'
+npx mudslide@latest --connect-timeout 10000 send me 'hello world'
 ```
 
 ### Query timeout


### PR DESCRIPTION
### Problem

The README's **Timeouts → Connection timeout** section documents a `--connection-timeout <ms>` flag, including a copy-pasteable example. The option registered in the CLI is actually named `--connect-timeout`, and Commander errors out on unknown options, so the documented command fails before anything else happens.

Doc side — `README.md` lines 397 and 400 on `main`:

> The default connection timeout is 3000 ms. This duration can be
> changed using the `--connection-timeout <ms>` flag:
>
> `npx mudslide@latest --connection-timeout 10000 send me 'hello world'`

Code side — `src/index.ts:52-53`:

```ts
program.addOption(
    new Option('--connect-timeout <ms>', 'Connection timeout').default(3_000).argParser(v => parseInt(v, 10)));
program.on('option:connect-timeout', (ms) => globalOptions.connectTimeoutMs = parseInt(ms, 10));
```

The 3000 ms default quoted in the README matches `.default(3_000)`, so it is the same option — only the name in the docs drifted. The two sibling sections right below are already correct (`--query-timeout` matches `src/index.ts:54`, `--timeout <seconds>` matches `src/index.ts:56`).

### Change

Two lines in `README.md`, no code change: `--connection-timeout` → `--connect-timeout` in the prose and in the shell example.

### Verification

Actually run on a clean clone of `main` (`e0ef403`), after `npm install && npm run build`:

```console
$ git grep -n -- 'connection-timeout'
README.md:397:changed using the `--connection-timeout <ms>` flag:
README.md:400:npx mudslide@latest --connection-timeout 10000 send me 'hello world'

$ git grep -n -- 'connect-timeout' -- src/
src/index.ts:52:    new Option('--connect-timeout <ms>', 'Connection timeout').default(3_000).argParser(v => parseInt(v, 10)));
src/index.ts:53:program.on('option:connect-timeout', (ms) => globalOptions.connectTimeoutMs = parseInt(ms, 10));

$ node build/index.js --connection-timeout 10000 send me 'hello world'
error: unknown option '--connection-timeout'
(Did you mean --connect-timeout?)
exit=1

$ node build/index.js --connect-timeout 10000 send   # args withheld on purpose, so no message is sent
error: missing required argument 'recipient'
exit=1                                               # global option accepted; parsing reached the subcommand

$ node build/index.js --help | grep -- 'timeout'
  --connect-timeout <ms>    Connection timeout (default: 3000)
  --query-timeout <ms>      Query timeout (default: 6000)
  --timeout <sec>           Command timeout (default: 60)
```

Commander itself suggests `--connect-timeout`, which is the name this PR adopts. After the change, `git grep -n -- 'connection-timeout'` returns no hits.

### Limitations

- Documentation only — `git diff --stat` is `README.md | 4 ++--`, so CI (`npm install` / `npm run build` / `npm test`) is unaffected.
- While checking, I noticed `README.md:288` documents `-wait-ack <ms>` (single dash) while `git grep -nE 'wait[-_]?[Aa]ck|waitAck' -- src/` returns zero hits. That looks like a separate issue needing your call on intent, so I deliberately left it out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
